### PR TITLE
Fix skeletons deprecated background color method

### DIFF
--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -53,7 +53,7 @@ class SkeletonAvatar extends StatelessWidget {
                       style.maxHeight ?? constraints.maxHeight)
                   : style.height,
               decoration: BoxDecoration(
-                color: Theme.of(context).backgroundColor,
+                color: Theme.of(context).colorScheme.background,
                 shape: style.shape,
                 borderRadius:
                     style.shape != BoxShape.circle ? style.borderRadius : null,
@@ -97,7 +97,7 @@ class SkeletonLine extends StatelessWidget {
                       : style.width,
                   height: style.height,
                   decoration: BoxDecoration(
-                    color: Theme.of(context).backgroundColor,
+                    color: Theme.of(context).colorScheme.background,
                     borderRadius: style.borderRadius,
                   ),
                 );


### PR DESCRIPTION
In this PR we introduce fixes for deprecated background methods happening in flutter 3.x.x versions.